### PR TITLE
Redis User improvements

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,1 @@
-test/*
+test/docker*

--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ class Registrar extends Emitter {
     const key = makeUserKey(aor);
     try {
       const result = await this.client.del(key);
-      const sortedSetResult = await this.client.zrem('active-user', aor);
+      const sortedSetResult = await this.client.zrem('active-user', key);
       debug(`Registrar#remove ${aor} result=${result} expiredKeys=${sortedSetResult}`);
       return result === 1 && sortedSetResult === 1;
     } catch (err) {

--- a/index.js
+++ b/index.js
@@ -136,7 +136,6 @@ class Registrar extends Emitter {
       //cleanup expired entries
       await this.client.zremrangebyscore('active-user', 0, Date.now());
       const keyPattern = realm ? `*${realm}` : '*';
-      const pattern = realm ? new RegExp('^(.*)@' + realm + '$') : new RegExp('^(.*)@.*$');
       const users = new Set();
       let idx = 0;
       do {
@@ -145,8 +144,10 @@ class Registrar extends Emitter {
         const keys = res[1];
         debug(next, keys, `Registrar:getCountOfUsers result from scan cursor ${idx} ${realm}`);
         keys.forEach((k) => {
-          const arr = pattern.exec(k);
-          if (arr) users.add(arr[1]);
+          //Ignore Scores
+          if (k.startsWith('user:')) {
+            users.add(k);
+          }
         });
         idx = parseInt(next);
       } while (idx !== 0);

--- a/index.js
+++ b/index.js
@@ -37,12 +37,10 @@ class Registrar extends Emitter {
     debug(`Registrar#add ${aor} from ${JSON.stringify(obj)} for ${expires}`);
     const key = makeUserKey(aor);
     try {
-      //cleanup expired entries
-      const expiredZResult = await this.client.zremrangebyscore('active-user', 0, Date.now());
       obj.expiryTime = Date.now() + (expires * 1000);
       const result = await this.client.setex(key, expires, JSON.stringify(obj));
       const zResult = await this.client.zadd('active-user', obj.expiryTime, key);
-      debug({result, zResult, expiredZResult, expires, obj}, `Registrar#add - result of adding ${aor}`);
+      debug({result, zResult, expires, obj}, `Registrar#add - result of adding ${aor}`);
       return result === 'OK' && zResult === 1;
     } catch (err) {
       this.logger.error(err, `Error adding user ${aor}`);

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ class Registrar extends Emitter {
       const result = await this.client.del(key);
       const sortedSetResult = await this.client.zrem('active-user', aor);
       debug(`Registrar#remove ${aor} result=${result} expiredKeys=${sortedSetResult}`);
-      return result === 1;
+      return result === 1 && sortedSetResult === 1;
     } catch (err) {
       this.logger.error(err, `Error removing aor ${aor}`);
       return false;

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ class Registrar extends Emitter {
     try {
       obj.expiryTime = Date.now() + (expires * 1000);
       const result = await this.client.setex(key, expires, JSON.stringify(obj));
-      const zResult = await this.client.zadd('active-user', obj.expiryTime, aor);
+      const zResult = await this.client.zadd('active-user', obj.expiryTime, key);
       const expiredZResult = await this.client.zremrangebyscore('active-user', 0, Date.now());
       debug({result, zResult, expiredZResult, expires, obj}, `Registrar#add - result of adding ${aor}`);
       return result === 'OK' && zResult === 1;

--- a/index.js
+++ b/index.js
@@ -17,6 +17,16 @@ class Registrar extends Emitter {
     }
     this.logger = logger;
     this.client = redisClient;
+
+    //cleanup expired entries
+    const cleanRateSeconds = 60 * 1000 * 10; //10 minutes
+    setInterval((rClient) => {
+      try {
+        rClient.zremrangebyscore('active-user', 0, Date.now());
+      } catch (err) {
+        this.logger.error(err, 'Error cleaning user interval');
+      }
+    }, cleanRateSeconds, redisClient);
   }
 
   /* for use by test suite only */

--- a/index.js
+++ b/index.js
@@ -1,13 +1,11 @@
 const debug = require('debug')('jambonz:mw-registrar');
 const Emitter = require('events');
 
-const noop = () => {};
+const noop = () => {
+};
 
 function makeUserKey(aor) {
   return `user:${aor}`;
-}
-function makeUserPattern(realm) {
-  return realm ? `user:*@${realm}` : 'user:*';
 }
 
 class Registrar extends Emitter {
@@ -29,9 +27,9 @@ class Registrar extends Emitter {
   /**
    * Add a registration for a user identified by a sip address-of-record
    * @param {String} aor - a sip address-of-record for a user (e.g. daveh@drachtio.org)
-   * @param {String} contact - the sip address where this user can be reached
-   * @param {String} sbcAddress - the sip uri address of the sbc that manages the connection to this user
-   * @param {String} protocol - the transport protocol used between the sbc and the user
+   * @param {String} obj.contact - the sip address where this user can be reached
+   * @param {String} obj.sbcAddress - the sip uri address of the sbc that manages the connection to this user
+   * @param {String} obj.protocol - the transport protocol used between the sbc and the user
    * @param {String} expires - number of seconds the registration for this user is active
    * @returns {Boolean} true if the registration was successfully added
    */
@@ -43,12 +41,14 @@ class Registrar extends Emitter {
       obj.expiryTime = now + (expires * 1000);
       const result = await this.client.setex(key, expires, JSON.stringify(obj));
       debug({result, expires, obj}, `Registrar#add - result of adding ${aor}`);
-      return result === 'OK';
+      const addResult = this.addToActiveUserHash(aor, obj.expiryTime);
+      return result === 'OK' && addResult;
     } catch (err) {
       this.logger.error(err, `Error adding user ${aor}`);
       return false;
     }
   }
+
 
   /**
    * Retrieve the registration details for a user
@@ -68,21 +68,28 @@ class Registrar extends Emitter {
 
   /**
    * Remove the registration for a user
-  * @param {String} aor - the address-of-record for the user
-  * @returns {Boolean} true if the registration was successfully removed
-  */
+   * @param {String} aor - the address-of-record for the user
+   * @returns {Boolean} true if the registration was successfully removed
+   */
   async remove(aor) {
     const key = makeUserKey(aor);
     try {
       const result = await this.client.del(key);
-      debug(`Registrar#remove ${aor} result: ${result}`);
-      return result === 1;
+      const hashResult = await this.removeUserFromHash(aor);
+      debug(`Registrar#remove ${aor} result: ${result} hasResult ${hashResult}`);
+      return result === 1 && hashResult;
     } catch (err) {
       this.logger.error(err, `Error removing aor ${aor}`);
       return false;
     }
   }
 
+  //todo
+  // keys shouldn't be used on a production redis as can degrade performance
+  // if this method is needed, suggest using scan instead.
+  // A quick search of repo and it looks like this method is used for tts cache counts.
+  // Maybe a simple set which holds expiry timestamps for each tts entry, this can easily be trimmed
+  // on each count invocation before returning the final count. This method could then be removed.
   async keys(prefix) {
     try {
       prefix = prefix || '*';
@@ -96,48 +103,103 @@ class Registrar extends Emitter {
     }
   }
 
+  /**
+   * if param realm exists then returns count of users belonging to a realm,
+   * otherwise returns count of all registered users
+   * @param {String} realm - nullable realm (e.g. drachtio.org)
+   * @returns {int} count of users
+   */
   async getCountOfUsers(realm) {
+    return this.getRegisteredUsersForRealm(realm).length;
+  }
+
+  /**
+   * if realm exists then returns all users belonging to a realm,
+   * otherwise returns all registered users
+   * @param {String} aor - the address-of-record for the user
+   * @param {String} expires - epoch milliseconds when object expires
+   * @returns {Boolean} true if the registration was successfully added
+   */
+  async addToActiveUserHash(aor, expires) {
     try {
-      const users = new Set();
-      let idx = 0;
-      const pattern = makeUserPattern(realm);
-      do {
-        const res = await this.client.scan([idx, 'MATCH', pattern, 'COUNT', 100]);
-        const next = res[0];
-        const keys = res[1];
-        debug(next, keys,  `Registrar:getCountOfUsers result from scan cursor ${idx} ${realm}`);
-        keys.forEach((k) => users.add(k));
-        idx = parseInt(next);
-      } while (idx !== 0);
-      return users.size;
+      const cleanupResult = this.cleanActiveUserHash(aor);
+      const addResult = await this.client.hset('active-user', `${expires}`, aor);
+      debug(`addToActiveUserHash - cleanupResult=${cleanupResult}, cleanupResult=${addResult}`);
+      return cleanupResult && addResult === 1;
     } catch (err) {
-      debug(err);
-      this.logger.error(err, 'getCountOfUsers: Error retrieving registered users');
+      this.logger.error(err, `Error addToActiveUserHash ${aor}`);
+      return false;
     }
   }
 
+  /**
+   * if param realm exists then returns all users belonging to a realm,
+   * otherwise returns all registered users
+   * @param {String} realm - nullable realm (e.g. drachtio.org)
+   * @returns {[String]} Set of userParts
+   */
   async getRegisteredUsersForRealm(realm) {
     try {
       const users = new Set();
-      let idx = 0;
-      const pattern = makeUserPattern(realm);
-      do {
-        const res = await this.client.scan([idx, 'MATCH', pattern, 'COUNT', 100]);
-        const next = res[0];
-        const keys = res[1];
-        debug(next, keys,  `Registrar:getCountOfUsers result from scan cursor ${idx} ${realm}`);
-        keys.forEach((k) => {
-          const arr = /^user:(.*)@.*$/.exec(k);
-          if (arr) users.add(arr[1]);
-        });
-        idx = parseInt(next);
-      } while (idx !== 0);
+      const activeUsers = await this.client.hgetall('active-user');
+      const pattern = realm ? new RegExp('user:(.*)@.*$') : new RegExp('^user:(.*)@' + realm + '$');
+      Object.keys(activeUsers).forEach((k) => {
+        const arr = pattern.exec(k);
+        if (arr) users.add(arr[1]);
+      });
       return [...users];
     } catch (err) {
       debug(err);
       this.logger.error(err, 'getRegisteredUsersForRealm: Error retrieving registered users');
     }
   }
+
+
+  /**
+   * Cleans any 'active-user' hash fields which have expired
+   * @param {String} aor - a sip address-of-record for a user (e.g. daveh@drachtio.org)
+   * @returns {Boolean} true if the cleanup was successful
+   */
+  async cleanActiveUserHash(aor) {
+    try {
+      const activeUsers = await this.client.hgetall('active-user');
+      const now = Date.now();
+      const fieldsToRemove = [];
+      const aorKeysToRemove = [];
+      Object.keys(activeUsers).forEach((k) => {
+        const valueExpires = Number(activeUsers[k]);
+        if (valueExpires < now) {
+          fieldsToRemove.push(k);
+          aorKeysToRemove.push(makeUserKey(k));
+        }
+      });
+      const removeExpiredResult = await this.client.hdel('active-user', fieldsToRemove);
+      const removeAORKeysResult = await this.client.del(aorKeysToRemove);
+      const success = removeExpiredResult === fieldsToRemove.length && removeAORKeysResult === aorKeysToRemove.length;
+      debug({aorKeysToRemove}, `Registrar#cleanActiveUserHash - ${fieldsToRemove.length} fields, success = ${success}`);
+      return success;
+    } catch (err) {
+      this.logger.error(err, 'Error cleanActiveUserHash');
+      return false;
+    }
+  }
+
+  /**
+   * removes a field from hash if value matches aor
+   * @param {String} aor - a sip address-of-record for a user (e.g. daveh@drachtio.org)
+   * @returns {Boolean} true if the cleanup was successful
+   */
+  async removeUserFromHash(aor) {
+    try {
+      const removeExpiredResult = await this.client.hdel('active-user', [aor]);
+      return removeExpiredResult === 1;
+    } catch (err) {
+      this.logger.error(err, 'Error removeUserFromHash');
+      return false;
+    }
+  }
+
+
 }
 
 module.exports = Registrar;

--- a/test/docker_start.js
+++ b/test/docker_start.js
@@ -1,11 +1,9 @@
-const test = require('tape') ;
-const exec = require('child_process').exec ;
+const test = require('tape');
+const path = require('path');
+const exec = require('child_process').exec;
 
 test('starting docker network..', (t) => {
-  exec(`docker-compose -f ${__dirname}/docker-compose-testbed.yaml up -d`, (err, stdout, stderr) => {
+  exec(`docker-compose -f ${__dirname}${path.sep}docker-compose-testbed.yaml up -d`, (err, stdout, stderr) => {
     t.end(err);
   });
-  
 });
-
-  

--- a/test/registrar-tests.js
+++ b/test/registrar-tests.js
@@ -64,7 +64,7 @@ test('registrar tests', async(t) => {
   result = await registrar.remove('dhorton@drachtio.org');
   t.ok(result === true, 'successfully removed aor');
 
-  const barFooUserCount = 30000;
+  const barFooUserCount = 10000;
   const fooBarUserCount = 1000;
 
   const barFooStart = process.hrtime();

--- a/test/registrar-tests.js
+++ b/test/registrar-tests.js
@@ -79,7 +79,7 @@ test('registrar tests', async(t) => {
   const barFooStart = process.hrtime();
   for (let i = 0; i < barFooUserCount; i++) {
     if (i % 1000 === 0) {
-      t.comment(`Added ${i} foobar users`);
+      t.comment(`Added ${i} barfoo.com users`);
     }
     await registrar.add(
       `user-${i}@barfoo.com`,
@@ -97,7 +97,7 @@ test('registrar tests', async(t) => {
   const fooBarStart = process.hrtime();
   for (let i = 0; i < fooBarUserCount; i++) {
     if (i % 100 === 0) {
-      t.comment(`Added ${i} foobar users`);
+      t.comment(`Added ${i} foobar.com users`);
     }
     await registrar.add(
       `user-${i}@foobar.com`,
@@ -115,19 +115,29 @@ test('registrar tests', async(t) => {
   const countBarFooTimeStart = process.hrtime();
   result = await registrar.getCountOfUsers('barfoo.com');
   const countBarFooTimeEnd = process.hrtime(countBarFooTimeStart);
+  const responseTimeBarFoo = Math.round(countBarFooTimeEnd[1] / 1000000);
   t.ok(
     result === barFooUserCount,
-    `counted all ${barFooUserCount} users in ${Math.round(countBarFooTimeEnd[1] / 1000000)}ms`,
+    `counted all ${barFooUserCount} barfoo.com users in ${responseTimeBarFoo}ms`,
   );
+  t.ok(
+    responseTimeBarFoo < 500,
+    `${barFooUserCount} barfoo.com users response time under 500ms`,
+  );
+
 
   const countFooBarTimeStart = process.hrtime();
   result = await registrar.getCountOfUsers('foobar.com');
   const countFooBarTimeEnd = process.hrtime(countFooBarTimeStart);
+  const responseTimeFooBar = Math.round(countFooBarTimeEnd[1] / 1000000);
   t.ok(
     result === fooBarUserCount,
-    `counted all ${fooBarUserCount} users in ${Math.round(countFooBarTimeEnd[1] / 1000000)}ms`,
+    `counted all ${fooBarUserCount} foobar.com users in ${responseTimeFooBar}ms`,
   );
-
+  t.ok(
+    responseTimeFooBar < 250,
+    `${fooBarUserCount} foobar.com users response time under 500ms`,
+  );
 
   t.end();
 });

--- a/test/registrar-tests.js
+++ b/test/registrar-tests.js
@@ -1,17 +1,8 @@
 const test = require('tape');
-// const debug = require('debug')('jambonz:middleware');
 
 process.on('unhandledRejection', (reason, p) => {
   console.log('Unhandled Rejection at: Promise', p, 'reason:', reason);
 });
-
-// function connect(connectable) {
-//   return new Promise((resolve, reject) => {
-//     connectable.on('connect', () => {
-//       return resolve();
-//     });
-//   });
-// }
 
 test('registrar tests', async(t) => {
   const Registrar = require('..');

--- a/test/registrar-tests.js
+++ b/test/registrar-tests.js
@@ -1,99 +1,133 @@
-const test = require("tape");
-const debug = require("debug")("jambonz:middleware");
+const test = require('tape');
+// const debug = require('debug')('jambonz:middleware');
 
-process.on("unhandledRejection", (reason, p) => {
-  console.log("Unhandled Rejection at: Promise", p, "reason:", reason);
+process.on('unhandledRejection', (reason, p) => {
+  console.log('Unhandled Rejection at: Promise', p, 'reason:', reason);
 });
 
-function connect(connectable) {
-  return new Promise((resolve, reject) => {
-    connectable.on("connect", () => {
-      return resolve();
-    });
-  });
-}
+// function connect(connectable) {
+//   return new Promise((resolve, reject) => {
+//     connectable.on('connect', () => {
+//       return resolve();
+//     });
+//   });
+// }
 
-test("registrar tests", async (t) => {
-  const Registrar = require("..");
-  const { client } = require("@jambonz/realtimedb-helpers")({
-    host: "127.0.0.1",
+test('registrar tests', async(t) => {
+  const Registrar = require('..');
+  const {client} = require('@jambonz/realtimedb-helpers')({
+    host: '127.0.0.1',
     port: 16379,
   });
   const registrar = new Registrar(null, client);
-  let timeStart, timeEnd;
 
   let result = await registrar.add(
-    "dhorton@drachtio.org",
+    'dhorton@drachtio.org',
     {
-      contact: "10.10.1.1",
-      sbcAddress: "192.168.1.1",
-      protocol: "udp",
+      contact: '10.10.1.1',
+      sbcAddress: '192.168.1.1',
+      protocol: 'udp',
     },
-    2
+    2,
   );
   t.ok(
     result,
-    "successfully added an address-of record to registrar with expires 2"
+    'successfully added an address-of record to registrar with expires 2',
   );
 
-  result = await registrar.getCountOfUsers("drachtio.org");
-  t.ok(result === 1, "count of users in realm returned 1");
+  result = await registrar.getCountOfUsers('drachtio.org');
+  t.ok(result === 1, 'count of users in realm returned 1');
 
   result = await registrar.getCountOfUsers();
-  t.ok(result === 1, "count of users in realm returned 1");
+  t.ok(result === 1, 'count of users in realm returned 1');
 
-  result = await registrar.query("dhorton@drachtio.org");
+  result = await registrar.query('dhorton@drachtio.org');
   t.ok(result !== null, `successfully retrieved ${JSON.stringify(result)}`);
 
-  result = await registrar.getRegisteredUsersForRealm("drachtio.org");
+  result = await registrar.getRegisteredUsersForRealm('drachtio.org');
   t.ok(result.length === 1, `successfully retrieved registered users ${JSON.stringify(result)}`);
 
   await new Promise((resolve) => setTimeout(() => resolve(), 2500));
 
-  result = await registrar.query("dhorton@drachtio.org");
-  t.ok(result === null, `address-of-record was removed after 2 secs`);
+  result = await registrar.query('dhorton@drachtio.org');
+  t.ok(result === null, 'address-of-record was removed after 2 secs');
 
-  result = await registrar.getCountOfUsers("drachtio.org");
-  t.ok(result === 0, "count of users in realm returned 0");
+  result = await registrar.getCountOfUsers('drachtio.org');
+  t.ok(result === 0, 'count of users in realm returned 0');
 
   result = await registrar.getCountOfUsers();
-  t.ok(result === 0, "count of total users returned 0");
+  t.ok(result === 0, 'count of total users returned 0');
 
   // read
   result = await registrar.add(
-    "dhorton@drachtio.org",
+    'dhorton@drachtio.org',
     {
-      contact: "10.10.1.1",
-      sbcAddress: "192.168.1.1",
-      protocol: "udp",
+      contact: '10.10.1.1',
+      sbcAddress: '192.168.1.1',
+      protocol: 'udp',
     },
-    2
+    2,
   );
-  t.ok(result, "successfully re-added aor");
+  t.ok(result, 'successfully re-added aor');
 
-  result = await registrar.remove("dhorton@drachtio.org");
-  t.ok(result == true, "successfully removed aor");
+  result = await registrar.remove('dhorton@drachtio.org');
+  t.ok(result === true, 'successfully removed aor');
 
-  const hrstart = process.hrtime();
-  for (let i = 0; i < 1000; i++) {
+  const barFooUserCount = 30000;
+  const fooBarUserCount = 1000;
+
+  const barFooStart = process.hrtime();
+  for (let i = 0; i < barFooUserCount; i++) {
+    if (i % 1000 === 0) {
+      t.comment(`Added ${i} foobar users`);
+    }
+    await registrar.add(
+      `user-${i}@barfoo.com`,
+      {
+        contact: '10.10.1.1',
+        sbcAddress: '192.168.1.1',
+        protocol: 'udp',
+      },
+      120,
+    );
+  }
+  const barFooEnd = process.hrtime(barFooStart);
+  t.pass(`added barfoo users in ${Math.round(barFooEnd[1] / 1000000)}ms`);
+
+  const fooBarStart = process.hrtime();
+  for (let i = 0; i < fooBarUserCount; i++) {
+    if (i % 100 === 0) {
+      t.comment(`Added ${i} foobar users`);
+    }
     await registrar.add(
       `user-${i}@foobar.com`,
       {
-        contact: "10.10.1.1",
-        sbcAddress: "192.168.1.1",
-        protocol: "udp",
+        contact: '10.10.1.1',
+        sbcAddress: '192.168.1.1',
+        protocol: 'udp',
       },
-      20
+      120,
     );
   }
-  const hrend = process.hrtime(hrstart);
-  t.pass(`added the users in ${Math.round(hrend[1] / 1000000)}ms`);
-  timeStart = process.hrtime();
-  result = await registrar.getCountOfUsers("foobar.com");
-  timeEnd = process.hrtime(timeStart)
+  const fooBarEnd = process.hrtime(fooBarStart);
+  t.pass(`added foobar users in ${Math.round(fooBarEnd[1] / 1000000)}ms`);
+
+  const countBarFooTimeStart = process.hrtime();
+  result = await registrar.getCountOfUsers('barfoo.com');
+  const countBarFooTimeEnd = process.hrtime(countBarFooTimeStart);
   t.ok(
-    result === 1000,
-    `counted all 1,000 users in ${Math.round(timeEnd[1] / 1000000)}ms`
+    result === barFooUserCount,
+    `counted all ${barFooUserCount} users in ${Math.round(countBarFooTimeEnd[1] / 1000000)}ms`,
   );
+
+  const countFooBarTimeStart = process.hrtime();
+  result = await registrar.getCountOfUsers('foobar.com');
+  const countFooBarTimeEnd = process.hrtime(countFooBarTimeStart);
+  t.ok(
+    result === fooBarUserCount,
+    `counted all ${fooBarUserCount} users in ${Math.round(countFooBarTimeEnd[1] / 1000000)}ms`,
+  );
+
+
   t.end();
 });

--- a/test/registrar-tests.js
+++ b/test/registrar-tests.js
@@ -126,7 +126,7 @@ test('registrar tests', async(t) => {
     `counted all ${fooBarUserCount} foobar.com users in ${responseTimeFooBar}ms`,
   );
   t.ok(
-    responseTimeFooBar < 250,
+    responseTimeFooBar < 500,
     `${fooBarUserCount} foobar.com users response time under 500ms`,
   );
 


### PR DESCRIPTION
I noticed high read ops on our redis cluster, looks like scan `user:*` is contributing to this.

Introduced a redis hash for referencing user registrations. Reduces need for scans for user counts.

Also need to discuss the keys command which i believe is being used by jambonz-api-server for tts count and could impact performance when keys grow into 1m+

Also as the user* keys are global to all jambonz clusters, I believe this is backwards compatible and allows each cluster to bump this lib individually.
